### PR TITLE
Cypress setup cleanup 594

### DIFF
--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -19,6 +19,7 @@ yarn.lock
 # cypress
 cypress/screenshots
 cypress/videos
+cypress.env.json
 
 # misc
 *.swp

--- a/integration/README.md
+++ b/integration/README.md
@@ -14,6 +14,17 @@ yarn test-cypress
 
 This will automatically start legacy, ui and proxy servers and run the Cypress tests, in which results are logged to the console. After running the tests, the servers and process will close.
 
+## Edit local configuration
+
+By default cypress will run tests using configuration defined in cypress.json.
+
+If you wish to overwrite any of the settings (like test a MAAS under a different URL or username/password) you can create a local configuration file:
+
+```shell
+cd integration
+touch cypress.env.json
+```
+
 ## Developing cypress tests
 
 ### On your host machine

--- a/integration/cypress.json
+++ b/integration/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:8400",
+  "baseUrl": "http://0.0.0.0:8400",
   "env": {
     "username": "admin",
     "password": "test"

--- a/integration/package.json
+++ b/integration/package.json
@@ -10,8 +10,8 @@
     "cypress-test": "yarn --cwd ../shared build && start-server-and-test serve-frontends '8401|8402' serve-base 'tcp:8400|8404' cypress-run",
     "serve-frontends": "yarn --cwd ../proxy serve-frontends",
     "serve-base": "yarn --cwd ../proxy serve-base",
-    "cypress-run": "yarn cypress run -c baseUrl=http://0.0.0.0:8400",
-    "cypress-open": "yarn cypress open -c baseUrl=http://0.0.0.0:8400"
+    "cypress-run": "yarn cypress run",
+    "cypress-open": "yarn cypress open"
   },
   "devDependencies": {
     "@maas-ui/maas-ui-shared": "3.2.0",


### PR DESCRIPTION
## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against *master* rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in master.
